### PR TITLE
Add max queue limit to testing workflow

### DIFF
--- a/.github/workflows/testing-queue.yml
+++ b/.github/workflows/testing-queue.yml
@@ -12,6 +12,7 @@ on:
 concurrency:
   group: queue-merge
   cancel-in-progress: false
+  queue: max
 
 jobs:
   PreTesting:


### PR DESCRIPTION
defaultだとsingleで、最新のqueueで上書きされるが、maxで複数待てるっぽいのでそれを試す